### PR TITLE
Corrección agregar un segundo PDF

### DIFF
--- a/dev/pdf-handler.js
+++ b/dev/pdf-handler.js
@@ -18,6 +18,7 @@ var pdfHandler = {
         pageNumber = parseInt(pageNumber) || 1;
 
         if (!pdfHandler.pdf) {
+            pageNumber = 1;
             pdfjsLib.disableWorker = false;
             pdfjsLib.getDocument(pdfHandler.lastPdfURL).then(function(pdf) {
                 pdfHandler.pdf = pdf;

--- a/widget.js
+++ b/widget.js
@@ -2651,6 +2651,7 @@
             pageNumber = parseInt(pageNumber) || 1;
 
             if (!pdfHandler.pdf) {
+                pageNumber = 1;
                 pdfjsLib.disableWorker = false;
                 pdfjsLib.getDocument(pdfHandler.lastPdfURL).then(function(pdf) {
                     pdfHandler.pdf = pdf;


### PR DESCRIPTION
Al tener agregado un pdf y visualizar un numero de pagina superior, al nuevo pdf a agregar, se produce un error con el pageNumber.

Con la modificación agregada, se permite abrir siempre un nuevo pdf en la pagina inicial.